### PR TITLE
Remove XSS vulnerability line 119

### DIFF
--- a/src/cytoscape-node-html-label.ts
+++ b/src/cytoscape-node-html-label.ts
@@ -115,10 +115,18 @@ interface CytoscapeContainerParams {
     }
 
     updateData(data: any) {
-      try {
-        this._node.innerHTML = this.tpl(data);
-      } catch (err) {
-        console.error(err);
+      while (this._node.firstChild) {
+        this._node.removeChild(this._node.firstChild);
+      }
+      const children = new DOMParser()
+                           .parseFromString(this.tpl(data), 'text/html')
+                           .body.children;
+      for (const el of Array.from(children)) {
+        try {
+          this._node.appendChild(el);
+        } catch (err) {
+          console.error(err);
+        }
       }
     }
 


### PR DESCRIPTION
Setting this._node.innerHTML = this.tpl(data); is an XSS vulnrability https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML
Is it possible to change this to appendChild as I have suggested?
I am using the cytoscape-node-html-label as part of my project and our linter is throwing an error when we try to submit the code to head.
This fix will be really useful if we can get it merged into this repo and remove the vulnrability.